### PR TITLE
Fixed flaky test

### DIFF
--- a/src/test/java/com/cedarsoftware/util/io/CollectionTests.java
+++ b/src/test/java/com/cedarsoftware/util/io/CollectionTests.java
@@ -345,7 +345,9 @@ public class CollectionTests {
         String json = TestUtil.toJson(arrayList, writeOptions);
         TestUtil.printLine(json);
         String className = CollectionTests.class.getName();
-        assertEquals("{\"@type\":\"java.util.ArrayList\",\"@items\":[{\"@type\":\"" + className + "$TestEnum4\",\"age\":21,\"foo\":\"bar\",\"name\":\"B\"}]}", json);
+	String expectedJson1 = "{\"@type\":\"java.util.ArrayList\",\"@items\":[{\"@type\":\"" + className + "$TestEnum4\",\"age\":21,\"foo\":\"bar\",\"name\":\"B\"}]}";
+	String expectedJson2 = "{\"@type\":\"java.util.ArrayList\",\"@items\":[{\"@type\":\"" + className + "$TestEnum4\",\"foo\":\"bar\",\"age\":21,\"name\":\"B\"}]}";
+        assertTrue(json.equals(expectedJson1) || json.equals(expectedJson2), "JSON does not match any expected form");
     }
 
     @Test


### PR DESCRIPTION
### What is the purpose of this PR
•	This PR fixes the error resulting from com.cedarsoftware.util.io.CollectionTests.testEnumsInsideOfACollection_whenWritingAsObject_withPrivateMembersIncluded
•	The test may fail or pass without changes made to the source code when it is run in different JVMs due to getDeclaredFields's non-deterministic return order.

### Why the test fails
•	The test converts the enum object TestEnum4 to json using the toJson function. The toJson function uses the method getDecalredFields() to get the fields in the enum object. 
•	The getDeclaredFields() method does not guarantee the order of the fields in the enum object. As the documentation for getDeclaredFields() states, “The elements in the returned array are not sorted and are not in any particular order”.

### Reproduce the test failure
Run the tests with NonDex maven plugin that was added in the pom.xml file. The command to recreate the flaky test failure is:
•	mvn test nondex:nondex -Dtest=CollectionTests

### Expected results
•	The test should run successfully when run with NonDex.

### Actual Result
```
[ERROR] Tests run: 17, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.656 s <<< FAILURE! -- in com.cedarsoftware.util.io.CollectionTests
[ERROR] com.cedarsoftware.util.io.CollectionTests.testEnumsInsideOfACollection_whenWritingAsObject_withPrivateMembersIncluded -- Time elapsed: 0.007 s <<< FAILURE!
org.opentest4j.AssertionFailedError: 
expected: <{"@type":"java.util.ArrayList","@items":[{"@type":"com.cedarsoftware.util.io.CollectionTests$TestEnum4","age":21,"foo":"bar","name":"B"}]}>
 but was: <{"@type":"java.util.ArrayList","@items":[{"@type":"com.cedarsoftware.util.io.CollectionTests$TestEnum4","foo":"bar","age":21,"name":"B"}]}>
```
### Fix
•	Changed the test to account for the two possible permutations when retrieving the class fields.

